### PR TITLE
Prepare GORM lib for v1 -> v2 migration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+name: Build
+
+on:
+  push:
+    branches-ignore: [master]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build 👷‍♀️
+    runs-on: ubuntu-latest
+    container: golang:1.19
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@main
+      
+      - name: Run tests
+        run: go test -v ./...

--- a/delete_test.go
+++ b/delete_test.go
@@ -1,8 +1,11 @@
 package gorm_test
 
 import (
+	"errors"
 	"testing"
 	"time"
+
+	"github.com/jinzhu/gorm"
 )
 
 func TestDelete(t *testing.T) {
@@ -14,11 +17,11 @@ func TestDelete(t *testing.T) {
 		t.Errorf("No error should happen when delete a record, err=%s", err)
 	}
 
-	if !DB.Where("name = ?", user1.Name).First(&User{}).RecordNotFound() {
+	if !errors.Is(DB.Where("name = ?", user1.Name).First(&User{}).Error, gorm.ErrRecordNotFound) {
 		t.Errorf("User can't be found after delete")
 	}
 
-	if DB.Where("name = ?", user2.Name).First(&User{}).RecordNotFound() {
+	if errors.Is(DB.Where("name = ?", user2.Name).First(&User{}).Error, gorm.ErrRecordNotFound) {
 		t.Errorf("Other users that not deleted should be found-able")
 	}
 }
@@ -30,13 +33,13 @@ func TestInlineDelete(t *testing.T) {
 
 	if DB.Delete(&User{}, user1.Id).Error != nil {
 		t.Errorf("No error should happen when delete a record")
-	} else if !DB.Where("name = ?", user1.Name).First(&User{}).RecordNotFound() {
+	} else if !errors.Is(DB.Where("name = ?", user1.Name).First(&User{}).Error, gorm.ErrRecordNotFound) {
 		t.Errorf("User can't be found after delete")
 	}
 
 	if err := DB.Delete(&User{}, "name = ?", user2.Name).Error; err != nil {
 		t.Errorf("No error should happen when delete a record, err=%s", err)
-	} else if !DB.Where("name = ?", user2.Name).First(&User{}).RecordNotFound() {
+	} else if !errors.Is(DB.Where("name = ?", user2.Name).First(&User{}).Error, gorm.ErrRecordNotFound) {
 		t.Errorf("User can't be found after delete")
 	}
 }
@@ -62,7 +65,7 @@ func TestSoftDelete(t *testing.T) {
 	}
 
 	DB.Unscoped().Delete(&user)
-	if !DB.Unscoped().First(&User{}, "name = ?", user.Name).RecordNotFound() {
+	if !errors.Is(DB.Unscoped().First(&User{}, "name = ?", user.Name).Error, gorm.ErrRecordNotFound) {
 		t.Errorf("Can't find permanently deleted record")
 	}
 }
@@ -85,7 +88,7 @@ func TestSoftDeleteWithCustomizedDeletedAtColumnName(t *testing.T) {
 	}
 
 	DB.Unscoped().Delete(&creditCard)
-	if !DB.Unscoped().First(&CreditCard{}, "number = ?", creditCard.Number).RecordNotFound() {
+	if !errors.Is(DB.Unscoped().First(&CreditCard{}, "number = ?", creditCard.Number).Error, gorm.ErrRecordNotFound) {
 		t.Errorf("Can't find permanently deleted record")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -46,15 +46,17 @@ const (
 
 // Open initialize a new db connection, need to import driver first, e.g:
 //
-//     import _ "github.com/go-sql-driver/mysql"
-//     func main() {
-//       db, err := gorm.Open("mysql", "user:password@/dbname?charset=utf8&parseTime=True&loc=Local")
-//     }
+//	import _ "github.com/go-sql-driver/mysql"
+//	func main() {
+//	  db, err := gorm.Open("mysql", "user:password@/dbname?charset=utf8&parseTime=True&loc=Local")
+//	}
+//
 // GORM has wrapped some drivers, for easier to remember driver's import path, so you could import the mysql driver with
-//    import _ "github.com/jinzhu/gorm/dialects/mysql"
-//    // import _ "github.com/jinzhu/gorm/dialects/postgres"
-//    // import _ "github.com/jinzhu/gorm/dialects/sqlite"
-//    // import _ "github.com/jinzhu/gorm/dialects/mssql"
+//
+//	import _ "github.com/jinzhu/gorm/dialects/mysql"
+//	// import _ "github.com/jinzhu/gorm/dialects/postgres"
+//	// import _ "github.com/jinzhu/gorm/dialects/sqlite"
+//	// import _ "github.com/jinzhu/gorm/dialects/mssql"
 func Open(dialect string, args ...interface{}) (db *DB, err error) {
 	if len(args) == 0 {
 		err = errors.New("invalid database source")
@@ -83,9 +85,9 @@ func Open(dialect string, args ...interface{}) (db *DB, err error) {
 	}
 
 	db = &DB{
-		db:        dbSQL,
-		logger:    defaultLogger,
-		
+		db:     dbSQL,
+		logger: defaultLogger,
+
 		// Create a clone of the default logger to avoid mutating a shared object when
 		// multiple gorm connections are created simultaneously.
 		callbacks: DefaultCallback.clone(defaultLogger),
@@ -126,12 +128,15 @@ func (s *DB) Close() error {
 
 // DB get `*sql.DB` from current connection
 // If the underlying database connection is not a *sql.DB, returns nil
-func (s *DB) DB() *sql.DB {
+//
+// Note: originally this panics in GORM v1 if !ok, but we prepare for a V2
+// migration so we return an error here instead.
+func (s *DB) DB() (*sql.DB, error) {
 	db, ok := s.db.(*sql.DB)
 	if !ok {
-		panic("can't support full GORM on currently status, maybe this is a TX instance.")
+		return nil, errors.New("can't support full GORM on currently status, maybe this is a TX instance")
 	}
-	return db
+	return db, nil
 }
 
 // CommonDB return the underlying `*sql.DB` or `*sql.Tx` instance, mainly intended to allow coexistence with legacy non-GORM code.
@@ -145,7 +150,9 @@ func (s *DB) Dialect() Dialect {
 }
 
 // Callback return `Callbacks` container, you could add/change/delete callbacks with it
-//     db.Callback().Create().Register("update_created_at", updateCreated)
+//
+//	db.Callback().Create().Register("update_created_at", updateCreated)
+//
 // Refer https://jinzhu.github.io/gorm/development.html#callbacks
 func (s *DB) Callback() *Callback {
 	s.parent.callbacks = s.parent.callbacks.clone(s.logger)
@@ -259,9 +266,10 @@ func (s *DB) Offset(offset interface{}) *DB {
 }
 
 // Order specify order when retrieve records from database, set reorder to `true` to overwrite defined conditions
-//     db.Order("name DESC")
-//     db.Order("name DESC", true) // reorder
-//     db.Order(gorm.Expr("name = ? DESC", "first")) // sql expression
+//
+//	db.Order("name DESC")
+//	db.Order("name DESC", true) // reorder
+//	db.Order(gorm.Expr("name = ? DESC", "first")) // sql expression
 func (s *DB) Order(value interface{}, reorder ...bool) *DB {
 	return s.clone().search.Order(value, reorder...).db
 }
@@ -288,23 +296,26 @@ func (s *DB) Having(query interface{}, values ...interface{}) *DB {
 }
 
 // Joins specify Joins conditions
-//     db.Joins("JOIN emails ON emails.user_id = users.id AND emails.email = ?", "jinzhu@example.org").Find(&user)
+//
+//	db.Joins("JOIN emails ON emails.user_id = users.id AND emails.email = ?", "jinzhu@example.org").Find(&user)
 func (s *DB) Joins(query string, args ...interface{}) *DB {
 	return s.clone().search.Joins(query, args...).db
 }
 
 // Scopes pass current database connection to arguments `func(*DB) *DB`, which could be used to add conditions dynamically
-//     func AmountGreaterThan1000(db *gorm.DB) *gorm.DB {
-//         return db.Where("amount > ?", 1000)
-//     }
 //
-//     func OrderStatus(status []string) func (db *gorm.DB) *gorm.DB {
-//         return func (db *gorm.DB) *gorm.DB {
-//             return db.Scopes(AmountGreaterThan1000).Where("status in (?)", status)
-//         }
-//     }
+//	func AmountGreaterThan1000(db *gorm.DB) *gorm.DB {
+//	    return db.Where("amount > ?", 1000)
+//	}
 //
-//     db.Scopes(AmountGreaterThan1000, OrderStatus([]string{"paid", "shipped"})).Find(&orders)
+//	func OrderStatus(status []string) func (db *gorm.DB) *gorm.DB {
+//	    return func (db *gorm.DB) *gorm.DB {
+//	        return db.Scopes(AmountGreaterThan1000).Where("status in (?)", status)
+//	    }
+//	}
+//
+//	db.Scopes(AmountGreaterThan1000, OrderStatus([]string{"paid", "shipped"})).Find(&orders)
+//
 // Refer https://jinzhu.github.io/gorm/crud.html#scopes
 func (s *DB) Scopes(funcs ...func(*DB) *DB) *DB {
 	for _, f := range funcs {
@@ -357,7 +368,7 @@ func (s *DB) Find(out interface{}, where ...interface{}) *DB {
 	return s.NewScope(out).inlineCondition(where...).callCallbacks(s.parent.callbacks.queries).db
 }
 
-//Preloads preloads relations, don`t touch out
+// Preloads preloads relations, don`t touch out
 func (s *DB) Preloads(out interface{}) *DB {
 	return s.NewScope(out).InstanceSet("gorm:only_preload", 1).callCallbacks(s.parent.callbacks.queries).db
 }
@@ -393,8 +404,9 @@ func (s *DB) ScanRows(rows *sql.Rows, result interface{}) error {
 }
 
 // Pluck used to query single column from a model as a map
-//     var ages []int64
-//     db.Find(&users).Pluck("age", &ages)
+//
+//	var ages []int64
+//	db.Find(&users).Pluck("age", &ages)
 func (s *DB) Pluck(column string, value interface{}) *DB {
 	return s.NewScope(s.Value).pluck(column, value).db
 }
@@ -414,7 +426,7 @@ func (s *DB) Related(value interface{}, foreignKeys ...string) *DB {
 func (s *DB) FirstOrInit(out interface{}, where ...interface{}) *DB {
 	c := s.clone()
 	if result := c.First(out, where...); result.Error != nil {
-		if !result.RecordNotFound() {
+		if !errors.Is(result.Error, ErrRecordNotFound) {
 			return result
 		}
 		c.NewScope(out).inlineCondition(where...).initialize()
@@ -429,7 +441,7 @@ func (s *DB) FirstOrInit(out interface{}, where ...interface{}) *DB {
 func (s *DB) FirstOrCreate(out interface{}, where ...interface{}) *DB {
 	c := s.clone()
 	if result := s.First(out, where...); result.Error != nil {
-		if !result.RecordNotFound() {
+		if !errors.Is(result.Error, ErrRecordNotFound) {
 			return result
 		}
 		return c.NewScope(out).inlineCondition(where...).initialize().callCallbacks(c.parent.callbacks.creates).db
@@ -493,7 +505,8 @@ func (s *DB) Delete(value interface{}, where ...interface{}) *DB {
 }
 
 // Raw use raw sql as conditions, won't run it unless invoked by other methods
-//    db.Raw("SELECT name, age FROM users WHERE name = ?", 3).Scan(&result)
+//
+//	db.Raw("SELECT name, age FROM users WHERE name = ?", 3).Scan(&result)
 func (s *DB) Raw(sql string, values ...interface{}) *DB {
 	return s.clone().search.Raw(true).Where(sql, values...).db
 }
@@ -508,10 +521,11 @@ func (s *DB) Exec(sql string, values ...interface{}) *DB {
 }
 
 // Model specify the model you would like to run db operations
-//    // update all users's name to `hello`
-//    db.Model(&User{}).Update("name", "hello")
-//    // if user's primary key is non-blank, will use it as condition, then will only update the user's name to `hello`
-//    db.Model(&user).Update("name", "hello")
+//
+//	// update all users's name to `hello`
+//	db.Model(&User{}).Update("name", "hello")
+//	// if user's primary key is non-blank, will use it as condition, then will only update the user's name to `hello`
+//	db.Model(&user).Update("name", "hello")
 func (s *DB) Model(value interface{}) *DB {
 	c := s.clone()
 	c.Value = value
@@ -624,16 +638,6 @@ func (s *DB) NewRecord(value interface{}) bool {
 	return s.NewScope(value).PrimaryKeyZero()
 }
 
-// RecordNotFound check if returning ErrRecordNotFound error
-func (s *DB) RecordNotFound() bool {
-	for _, err := range s.GetErrors() {
-		if err == ErrRecordNotFound {
-			return true
-		}
-	}
-	return false
-}
-
 // CreateTable create table for models
 func (s *DB) CreateTable(models ...interface{}) *DB {
 	db := s.Unscoped()
@@ -730,7 +734,8 @@ func (s *DB) RemoveIndex(indexName string) *DB {
 }
 
 // AddForeignKey Add foreign key to the given scope, e.g:
-//     db.Model(&User{}).AddForeignKey("city_id", "cities(id)", "RESTRICT", "RESTRICT")
+//
+//	db.Model(&User{}).AddForeignKey("city_id", "cities(id)", "RESTRICT", "RESTRICT")
 func (s *DB) AddForeignKey(field string, dest string, onDelete string, onUpdate string) *DB {
 	scope := s.NewScope(s.Value)
 	scope.addForeignKey(field, dest, onDelete, onUpdate)
@@ -738,7 +743,8 @@ func (s *DB) AddForeignKey(field string, dest string, onDelete string, onUpdate 
 }
 
 // RemoveForeignKey Remove foreign key from the given scope, e.g:
-//     db.Model(&User{}).RemoveForeignKey("city_id", "cities(id)")
+//
+//	db.Model(&User{}).RemoveForeignKey("city_id", "cities(id)")
 func (s *DB) RemoveForeignKey(field string, dest string) *DB {
 	scope := s.clone().NewScope(s.Value)
 	scope.removeForeignKey(field, dest)
@@ -768,7 +774,8 @@ func (s *DB) Association(column string) *Association {
 }
 
 // Preload preload associations with given conditions
-//    db.Preload("Orders", "state NOT IN (?)", "cancelled").Find(&users)
+//
+//	db.Preload("Orders", "state NOT IN (?)", "cancelled").Find(&users)
 func (s *DB) Preload(column string, conditions ...interface{}) *DB {
 	return s.clone().search.Preload(column, conditions...).db
 }

--- a/polymorphic_test.go
+++ b/polymorphic_test.go
@@ -1,9 +1,12 @@
 package gorm_test
 
 import (
+	"errors"
 	"reflect"
 	"sort"
 	"testing"
+
+	"github.com/jinzhu/gorm"
 )
 
 type Cat struct {
@@ -57,7 +60,7 @@ func TestPolymorphic(t *testing.T) {
 
 	// Query
 	var catToys []Toy
-	if DB.Model(&cat).Related(&catToys, "Toy").RecordNotFound() {
+	if errors.Is(DB.Model(&cat).Related(&catToys, "Toy").Error, gorm.ErrRecordNotFound) {
 		t.Errorf("Did not find any has one polymorphic association")
 	} else if len(catToys) != 1 {
 		t.Errorf("Should have found only one polymorphic has one association")
@@ -66,7 +69,7 @@ func TestPolymorphic(t *testing.T) {
 	}
 
 	var dogToys []Toy
-	if DB.Model(&dog).Related(&dogToys, "Toys").RecordNotFound() {
+	if errors.Is(DB.Model(&dog).Related(&dogToys, "Toys").Error, gorm.ErrRecordNotFound) {
 		t.Errorf("Did not find any polymorphic has many associations")
 	} else if len(dogToys) != len(dog.Toys) {
 		t.Errorf("Should have found all polymorphic has many associations")
@@ -171,7 +174,7 @@ func TestPolymorphic(t *testing.T) {
 
 	DB.Model(&cat).Association("Toy").Delete(&catToy3)
 
-	if !DB.Model(&cat).Related(&Toy{}, "Toy").RecordNotFound() {
+	if !errors.Is(DB.Model(&cat).Related(&Toy{}, "Toy").Error, gorm.ErrRecordNotFound) {
 		t.Errorf("Toy should be deleted with Delete")
 	}
 
@@ -252,7 +255,7 @@ func TestNamedPolymorphic(t *testing.T) {
 
 	// Query
 	var hamsterToys []Toy
-	if DB.Model(&hamster).Related(&hamsterToys, "PreferredToy").RecordNotFound() {
+	if errors.Is(DB.Model(&hamster).Related(&hamsterToys, "PreferredToy").Error, gorm.ErrRecordNotFound) {
 		t.Errorf("Did not find any has one polymorphic association")
 	} else if len(hamsterToys) != 1 {
 		t.Errorf("Should have found only one polymorphic has one association")
@@ -260,7 +263,7 @@ func TestNamedPolymorphic(t *testing.T) {
 		t.Errorf("Should have found the proper has one polymorphic association")
 	}
 
-	if DB.Model(&hamster).Related(&hamsterToys, "OtherToy").RecordNotFound() {
+	if errors.Is(DB.Model(&hamster).Related(&hamsterToys, "OtherToy").Error, gorm.ErrRecordNotFound) {
 		t.Errorf("Did not find any has one polymorphic association")
 	} else if len(hamsterToys) != 1 {
 		t.Errorf("Should have found only one polymorphic has one association")

--- a/query_test.go
+++ b/query_test.go
@@ -1,6 +1,7 @@
 package gorm_test
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -173,11 +174,11 @@ func TestSearchWithPlainSQL(t *testing.T) {
 	DB.Save(&user1).Save(&user2).Save(&user3)
 	scopedb := DB.Where("name LIKE ?", "%PlainSqlUser%")
 
-	if DB.Where("name = ?", user1.Name).First(&User{}).RecordNotFound() {
+	if errors.Is(DB.Where("name = ?", user1.Name).First(&User{}).Error, gorm.ErrRecordNotFound) {
 		t.Errorf("Search with plain SQL")
 	}
 
-	if DB.Where("name LIKE ?", "%"+user1.Name+"%").First(&User{}).RecordNotFound() {
+	if errors.Is(DB.Where("name LIKE ?", "%"+user1.Name+"%").First(&User{}).Error, gorm.ErrRecordNotFound) {
 		t.Errorf("Search with plan SQL (regexp)")
 	}
 
@@ -235,7 +236,7 @@ func TestSearchWithPlainSQL(t *testing.T) {
 		t.Error("no error should happen when query with empty slice, but got: ", err)
 	}
 
-	if DB.Where("name = ?", "none existing").Find(&[]User{}).RecordNotFound() {
+	if errors.Is(DB.Where("name = ?", "none existing").Find(&[]User{}).Error, gorm.ErrRecordNotFound) {
 		t.Errorf("Should not get RecordNotFound error when looking for none existing records")
 	}
 }
@@ -276,15 +277,15 @@ func TestSearchWithStruct(t *testing.T) {
 	user3 := User{Name: "StructSearchUser3", Age: 20, Birthday: parseTime("2020-1-1")}
 	DB.Save(&user1).Save(&user2).Save(&user3)
 
-	if DB.Where(user1.Id).First(&User{}).RecordNotFound() {
+	if errors.Is(DB.Where(user1.Id).First(&User{}).Error, gorm.ErrRecordNotFound) {
 		t.Errorf("Search with primary key")
 	}
 
-	if DB.First(&User{}, user1.Id).RecordNotFound() {
+	if errors.Is(DB.First(&User{}, user1.Id).Error, gorm.ErrRecordNotFound) {
 		t.Errorf("Search with primary key as inline condition")
 	}
 
-	if DB.First(&User{}, fmt.Sprintf("%v", user1.Id)).RecordNotFound() {
+	if errors.Is(DB.First(&User{}, fmt.Sprintf("%v", user1.Id)).Error, gorm.ErrRecordNotFound) {
 		t.Errorf("Search with primary key as inline condition")
 	}
 
@@ -771,11 +772,11 @@ func TestFindOrCreate(t *testing.T) {
 	}
 
 	DB.Where(&User{Name: "find or create embedded struct"}).Assign(User{Age: 44, CreditCard: CreditCard{Number: "1231231231"}, Emails: []Email{{Email: "jinzhu@assign_embedded_struct.com"}, {Email: "jinzhu-2@assign_embedded_struct.com"}}}).FirstOrCreate(&user8)
-	if DB.Where("email = ?", "jinzhu-2@assign_embedded_struct.com").First(&Email{}).RecordNotFound() {
+	if errors.Is(DB.Where("email = ?", "jinzhu-2@assign_embedded_struct.com").First(&Email{}).Error, gorm.ErrRecordNotFound) {
 		t.Errorf("embedded struct email should be saved")
 	}
 
-	if DB.Where("email = ?", "1231231231").First(&CreditCard{}).RecordNotFound() {
+	if errors.Is(DB.Where("email = ?", "1231231231").First(&CreditCard{}).Error, gorm.ErrRecordNotFound) {
 		t.Errorf("embedded struct credit card should be saved")
 	}
 }

--- a/update_test.go
+++ b/update_test.go
@@ -1,6 +1,7 @@
 package gorm_test
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -21,15 +22,15 @@ func TestUpdate(t *testing.T) {
 	DB.First(&product2, product2.Id)
 	updatedAt1 := product1.UpdatedAt
 
-	if DB.First(&Product{}, "code = ?", product1.Code).RecordNotFound() {
+	if errors.Is(DB.First(&Product{}, "code = ?", product1.Code).Error, gorm.ErrRecordNotFound) {
 		t.Errorf("Product1 should not be updated")
 	}
 
-	if !DB.First(&Product{}, "code = ?", "product2code").RecordNotFound() {
+	if !errors.Is(DB.First(&Product{}, "code = ?", "product2code").Error, gorm.ErrRecordNotFound) {
 		t.Errorf("Product2's code should be updated")
 	}
 
-	if DB.First(&Product{}, "code = ?", "product2newcode").RecordNotFound() {
+	if errors.Is(DB.First(&Product{}, "code = ?", "product2newcode").Error, gorm.ErrRecordNotFound) {
 		t.Errorf("Product2's code should be updated")
 	}
 
@@ -41,11 +42,11 @@ func TestUpdate(t *testing.T) {
 		t.Errorf("updatedAt should be updated if something changed")
 	}
 
-	if !DB.First(&Product{}, "code = 'product1code'").RecordNotFound() {
+	if !errors.Is(DB.First(&Product{}, "code = 'product1code'").Error, gorm.ErrRecordNotFound) {
 		t.Errorf("Product1's code should be updated")
 	}
 
-	if DB.First(&Product{}, "code = 'product1newcode'").RecordNotFound() {
+	if errors.Is(DB.First(&Product{}, "code = 'product1newcode'").Error, gorm.ErrRecordNotFound) {
 		t.Errorf("Product should not be changed to 789")
 	}
 
@@ -130,16 +131,16 @@ func TestUpdates(t *testing.T) {
 	DB.First(&product2, product2.Id)
 	updatedAt2 := product2.UpdatedAt
 
-	if DB.First(&Product{}, "code = ? and price = ?", product2.Code, product2.Price).RecordNotFound() {
+	if errors.Is(DB.First(&Product{}, "code = ? and price = ?", product2.Code, product2.Price).Error, gorm.ErrRecordNotFound) {
 		t.Errorf("Product2 should not be updated")
 	}
 
-	if DB.First(&Product{}, "code = ?", "product1newcode").RecordNotFound() {
+	if errors.Is(DB.First(&Product{}, "code = ?", "product1newcode").Error, gorm.ErrRecordNotFound) {
 		t.Errorf("Product1 should be updated")
 	}
 
 	DB.Table("products").Where("code in (?)", []string{"product2code"}).Updates(Product{Code: "product2newcode"})
-	if !DB.First(&Product{}, "code = 'product2code'").RecordNotFound() {
+	if !errors.Is(DB.First(&Product{}, "code = 'product2code'").Error, gorm.ErrRecordNotFound) {
 		t.Errorf("Product2's code should be updated")
 	}
 
@@ -149,7 +150,7 @@ func TestUpdates(t *testing.T) {
 		t.Errorf("updatedAt should be updated if something changed")
 	}
 
-	if DB.First(&Product{}, "code = ?", "product2newcode").RecordNotFound() {
+	if errors.Is(DB.First(&Product{}, "code = ?", "product2newcode").Error, gorm.ErrRecordNotFound) {
 		t.Errorf("product2's code should be updated")
 	}
 


### PR DESCRIPTION
Two changes:
- GORM V2 does not have `RecordNotFound()` method which would be one of the biggest changes in our `backend` repo.
- `DB()` method returns `(*sql.DB, error)` in GORM v2, so I modified that too.