### PR TITLE
Gorm v2 migration 2024, part 1

### DIFF
--- a/callback_create.go
+++ b/callback_create.go
@@ -21,10 +21,10 @@ func init() {
 // beforeCreateCallback will invoke `BeforeSave`, `BeforeCreate` method before creating
 func beforeCreateCallback(scope *Scope) {
 	if !scope.HasError() {
-		scope.CallMethod("BeforeSave")
+		scope.CallMethod("BeforeSaveV1")
 	}
 	if !scope.HasError() {
-		scope.CallMethod("BeforeCreate")
+		scope.CallMethod("BeforeCreateV1")
 	}
 }
 
@@ -196,9 +196,9 @@ func forceReloadAfterCreateCallback(scope *Scope) {
 // afterCreateCallback will invoke `AfterCreate`, `AfterSave` method after creating
 func afterCreateCallback(scope *Scope) {
 	if !scope.HasError() {
-		scope.CallMethod("AfterCreate")
+		scope.CallMethod("AfterCreateV1")
 	}
 	if !scope.HasError() {
-		scope.CallMethod("AfterSave")
+		scope.CallMethod("AfterSaveV1")
 	}
 }

--- a/callback_delete.go
+++ b/callback_delete.go
@@ -21,7 +21,7 @@ func beforeDeleteCallback(scope *Scope) {
 		return
 	}
 	if !scope.HasError() {
-		scope.CallMethod("BeforeDelete")
+		scope.CallMethod("BeforeDeleteV1")
 	}
 }
 
@@ -58,6 +58,6 @@ func deleteCallback(scope *Scope) {
 // afterDeleteCallback will invoke `AfterDelete` method after deleting
 func afterDeleteCallback(scope *Scope) {
 	if !scope.HasError() {
-		scope.CallMethod("AfterDelete")
+		scope.CallMethod("AfterDeleteV1")
 	}
 }

--- a/callback_query.go
+++ b/callback_query.go
@@ -100,6 +100,6 @@ func queryCallback(scope *Scope) {
 // afterQueryCallback will invoke `AfterFind` method after querying
 func afterQueryCallback(scope *Scope) {
 	if !scope.HasError() {
-		scope.CallMethod("AfterFind")
+		scope.CallMethod("AfterFindV1")
 	}
 }

--- a/callback_update.go
+++ b/callback_update.go
@@ -39,10 +39,10 @@ func beforeUpdateCallback(scope *Scope) {
 	}
 	if _, ok := scope.Get("gorm:update_column"); !ok {
 		if !scope.HasError() {
-			scope.CallMethod("BeforeSave")
+			scope.CallMethod("BeforeSaveV1")
 		}
 		if !scope.HasError() {
-			scope.CallMethod("BeforeUpdate")
+			scope.CallMethod("BeforeUpdateV1")
 		}
 	}
 }
@@ -112,10 +112,10 @@ func updateCallback(scope *Scope) {
 func afterUpdateCallback(scope *Scope) {
 	if _, ok := scope.Get("gorm:update_column"); !ok {
 		if !scope.HasError() {
-			scope.CallMethod("AfterUpdate")
+			scope.CallMethod("AfterUpdateV1")
 		}
 		if !scope.HasError() {
-			scope.CallMethod("AfterSave")
+			scope.CallMethod("AfterSaveV1")
 		}
 	}
 }

--- a/callbacks_test.go
+++ b/callbacks_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/jinzhu/gorm"
 )
 
-func (s *Product) BeforeCreate() (err error) {
+func (s *Product) BeforeCreateV1() (err error) {
 	if s.Code == "Invalid" {
 		err = errors.New("invalid product")
 	}
@@ -16,7 +16,7 @@ func (s *Product) BeforeCreate() (err error) {
 	return
 }
 
-func (s *Product) BeforeUpdate() (err error) {
+func (s *Product) BeforeUpdateV1() (err error) {
 	if s.Code == "dont_update" {
 		err = errors.New("can't update")
 	}
@@ -24,7 +24,7 @@ func (s *Product) BeforeUpdate() (err error) {
 	return
 }
 
-func (s *Product) BeforeSave() (err error) {
+func (s *Product) BeforeSaveV1() (err error) {
 	if s.Code == "dont_save" {
 		err = errors.New("can't save")
 	}
@@ -32,19 +32,19 @@ func (s *Product) BeforeSave() (err error) {
 	return
 }
 
-func (s *Product) AfterFind() {
+func (s *Product) AfterFindV1() {
 	s.AfterFindCallTimes = s.AfterFindCallTimes + 1
 }
 
-func (s *Product) AfterCreate(tx *gorm.DB) {
+func (s *Product) AfterCreateV1(tx *gorm.DB) {
 	tx.Model(s).UpdateColumn(Product{AfterCreateCallTimes: s.AfterCreateCallTimes + 1})
 }
 
-func (s *Product) AfterUpdate() {
+func (s *Product) AfterUpdateV1() {
 	s.AfterUpdateCallTimes = s.AfterUpdateCallTimes + 1
 }
 
-func (s *Product) AfterSave() (err error) {
+func (s *Product) AfterSaveV1() (err error) {
 	if s.Code == "after_save_error" {
 		err = errors.New("can't save")
 	}
@@ -52,7 +52,7 @@ func (s *Product) AfterSave() (err error) {
 	return
 }
 
-func (s *Product) BeforeDelete() (err error) {
+func (s *Product) BeforeDeleteV1() (err error) {
 	if s.Code == "dont_delete" {
 		err = errors.New("can't delete")
 	}
@@ -60,7 +60,7 @@ func (s *Product) BeforeDelete() (err error) {
 	return
 }
 
-func (s *Product) AfterDelete() (err error) {
+func (s *Product) AfterDeleteV1() (err error) {
 	if s.Code == "after_delete_error" {
 		err = errors.New("can't delete")
 	}

--- a/embedded_struct_test.go
+++ b/embedded_struct_test.go
@@ -16,7 +16,7 @@ type Author struct {
 
 type HNPost struct {
 	BasePost
-	Author  `gorm:"embedded_prefix:user_"` // Embedded struct
+	Author  `gorm:"embeddedPrefix:user_"` // Embedded struct
 	Upvotes int32
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -108,7 +108,7 @@ func TestOpen_ReturnsError_WithBadArgs(t *testing.T) {
 
 func TestStringPrimaryKey(t *testing.T) {
 	type UUIDStruct struct {
-		ID   string `gorm:"primary_key"`
+		ID   string `gorm:"primaryKey"`
 		Name string
 	}
 	DB.DropTable(&UUIDStruct{})

--- a/multi_primary_keys_test.go
+++ b/multi_primary_keys_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 type Blog struct {
-	ID         uint   `gorm:"primary_key"`
-	Locale     string `gorm:"primary_key"`
+	ID         uint   `gorm:"primaryKey"`  // New V2 style to define primary key
+	Locale     string `gorm:"primary_key"` // Old V1 style to define primary key
 	Subject    string
 	Body       string
 	Tags       []Tag `gorm:"many2many:blog_tags;"`

--- a/scope.go
+++ b/scope.go
@@ -1303,7 +1303,13 @@ func (scope *Scope) autoIndex() *Scope {
 			}
 		}
 
-		if name, ok := field.TagSettingsGet("UNIQUE_INDEX"); ok {
+		// Compatibility with GORM v2
+		name, ok := field.TagSettingsGet("UNIQUE_INDEX")
+		if !ok {
+			name, ok = field.TagSettingsGet("UNIQUEINDEX")
+		}
+
+		if ok {
 			names := strings.Split(name, ",")
 
 			for _, name := range names {


### PR DESCRIPTION
Two changes:

- The callbacks got a `V1` postfix because they are not compatible with GORM V2 at all. In GORM V1 it's `callback(gorm.Scope)` in GORM V2 it's `callback(gorm.DB)`
- Struct tags. From now, it'll accept both `primaryKey` instead of `primary_key`. Obviously they needed to change this in GORM V2. 😄 
