### PR TITLE
fix: do not panic when db is a `nil`

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -867,7 +867,7 @@ func (scope *Scope) callCallbacks(funcs []*func(s *Scope)) *Scope {
 				if db != nil {
 					db.Rollback()
 				} else {
-					panic(fmt.Errorf("db is nil during a Rallback: %v", err))
+					panic(fmt.Errorf("db is nil during a Rollback: %v", err))
 				}
 			}
 			panic(err)

--- a/scope.go
+++ b/scope.go
@@ -864,7 +864,11 @@ func (scope *Scope) callCallbacks(funcs []*func(s *Scope)) *Scope {
 	defer func() {
 		if err := recover(); err != nil {
 			if db, ok := scope.db.db.(sqlTx); ok {
-				db.Rollback()
+				if db != nil {
+					db.Rollback()
+				} else {
+					panic(fmt.Errorf("db is nil during a Rallback: %v", err))
+				}
 			}
 			panic(err)
 		}


### PR DESCRIPTION
In this PR, I add a check for the `db`'s `nil`ability. If we reach the problem, the panic will contain the previous error which should help debug the root cause.

Make sure these boxes are checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?
