### PR TITLE
fix(panic): let's check db isn't nil

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -862,8 +862,9 @@ func (scope *Scope) inlineCondition(values ...interface{}) *Scope {
 
 func (scope *Scope) callCallbacks(funcs []*func(s *Scope)) *Scope {
 	defer func() {
+		var emptySQLTx *sql.Tx
 		if err := recover(); err != nil {
-			if db, ok := scope.db.db.(sqlTx); ok {
+			if db, ok := scope.db.db.(sqlTx); ok && db != nil && db != emptySQLTx {
 				db.Rollback()
 			}
 			panic(err)


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?

[BugSnag](https://app.bugsnag.com/spacelift/spacelift-backend-prod/errors/66b263bded72fb16059bfb83?filters[event.before]=2024-08-06T17%3A59%3A00.000Z&filters[event.since]=2024-08-06T17%3A55%3A00.000Z&pivot_tab=event)

Let's check if the DB is nil - it's possible because if `BeginTx` returns an error, we will set nil:
![Screenshot 2024-08-07 at 09 38 15](https://github.com/user-attachments/assets/a0f74a77-9615-4dd3-9e87-0d54cf0687b0).


